### PR TITLE
Page structureリファクタリング

### DIFF
--- a/src/app/teams/_components/teams-template/index.ts
+++ b/src/app/teams/_components/teams-template/index.ts
@@ -1,0 +1,2 @@
+export * from "./teams-template";
+

--- a/src/app/teams/_components/teams-template/teams-template.tsx
+++ b/src/app/teams/_components/teams-template/teams-template.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import TeamsTemplateImpl from "@/components/templates/TeamsTemplate/TeamsTemplate";
+
+/**
+ * チーム一覧ページテンプレート（route 配下に寄せるためのエントリ）
+ *
+ * NOTE:
+ * 現状の実装は `src/components/templates/TeamsTemplate` をそのまま利用し、
+ * import 経路だけ `(home)` と同じ「ページ配下の _components」へ揃える。
+ * 実装の移設は段階的に行う。
+ */
+export const TeamsTemplate: React.FC<React.ComponentProps<typeof TeamsTemplateImpl>> =
+  (props) => <TeamsTemplateImpl {...props} />;
+

--- a/src/app/teams/page.tsx
+++ b/src/app/teams/page.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { axiosBase } from "@/lib/axiosBase";
 import { GetActiveTeamProfileListResponse } from "../api/nba/teams/active/route";
-import TeamsTemplate from "@/components/templates/TeamsTemplate/TeamsTemplate";
+import { TeamsTemplate } from "./_components/teams-template";
 
 // ビルド時のスタティック生成を無効化
 export const dynamic = "force-dynamic";


### PR DESCRIPTION
`teams` ページのコンポーネント構造を `(home)` ディレクトリに合わせるため、`TeamsTemplate` のエントリポイントを `src/app/teams/_components` に追加し、`page.tsx` の参照先を更新します。

---
<a href="https://cursor.com/background-agent?bcId=bc-2e7e5ea0-7aff-408b-b0b5-ae519dc66c61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e7e5ea0-7aff-408b-b0b5-ae519dc66c61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>